### PR TITLE
Added Json Content Collection and optimized code

### DIFF
--- a/DistributionPackages/NeosExampleJsonApi.Site/Resources/Private/Fusion/Content/Headline/HeadlineJson.fusion
+++ b/DistributionPackages/NeosExampleJsonApi.Site/Resources/Private/Fusion/Content/Headline/HeadlineJson.fusion
@@ -1,6 +1,3 @@
-prototype(NeosExampleJsonApi.Site:Content.Headline.Json) < prototype(Neos.Neos:ContentComponent) {
-    renderer = Neos.Fusion:DataStructure {
-        nodeType = ${q(node).property('_nodeType.name')}
-        title = ${q(node).property('title')}
-    }
+prototype(NeosExampleJsonApi.Site:Content.Headline.Json) < prototype(NeosExampleJsonApi.Site:DefaultView.Json) {
+    title = ${q(node).property('title')}
 }

--- a/DistributionPackages/NeosExampleJsonApi.Site/Resources/Private/Fusion/Content/Text/TextJson.fusion
+++ b/DistributionPackages/NeosExampleJsonApi.Site/Resources/Private/Fusion/Content/Text/TextJson.fusion
@@ -1,6 +1,3 @@
-prototype(NeosExampleJsonApi.Site:Content.Text.Json) < prototype(Neos.Neos:ContentComponent) {
-    renderer = Neos.Fusion:DataStructure {
-        nodeType = ${q(node).property('_nodeType.name')}
-        text = ${q(node).property('text')}
-    }
+prototype(NeosExampleJsonApi.Site:Content.Text.Json) < prototype(NeosExampleJsonApi.Site:DefaultView.Json) {
+    text = ${q(node).property('text')}
 }

--- a/DistributionPackages/NeosExampleJsonApi.Site/Resources/Private/Fusion/Document/Page/PageJson.fusion
+++ b/DistributionPackages/NeosExampleJsonApi.Site/Resources/Private/Fusion/Document/Page/PageJson.fusion
@@ -1,62 +1,36 @@
 prototype(NeosExampleJsonApi.Site:Document.Page.Json) < prototype(Neos.Fusion:Component) {
-    renderer = Neos.Fusion:DataStructure {
-        nodeId = ${node.identifier}
-        nodePath = ${q(node).property('_path')}
+    renderer = NeosExampleJsonApi.Site:DefaultView.Json {
+
+        nodeTitle = ${q(node).property('title')}
         nodeUri = Neos.Neos:NodeUri {
-            node = ${documentNode}
+            node = ${node}
         }
-        nodeType = ${q(node).property('_nodeType.name')}
+        nodePath = ${q(node).property('_path')}
 
-        content = Neos.Fusion:Map {
-            items = ${q(node).children('main').children()}
-            itemName = 'item'
-            itemRenderer = Neos.Fusion:Case {
-                jsonView {
-                    condition = Neos.Fusion:CanRender {
-                        type = ${q(item).property('_nodeType.name') + '.Json'}
-                    }
-                    type = ${q(item).property('_nodeType.name') + '.Json'}
-                    @context.node = ${item}
-                }
-                defaultView {
-                    condition = true
-                    type = 'NeosExampleJsonApi.Site:DefaultView.Json'
-                    @context.node = ${item}
-                }
-            }
+
+        content = NeosExampleJsonApi.Site:ContentCollectionJson {
+            nodePath = 'main'
         }
 
+        # TODO: Make recursive instead of 1 Level childpages.
+        # @process.stringify is only allowed on entry page.
         childPages = Neos.Fusion:Map {
-            items = ${q(documentNode).children('[instanceof NeosExampleJsonApi.Site:Document.Page]')}
-            itemName = 'item'
-            itemRenderer = Neos.Fusion:DataStructure {
-                type = ${q(item).property('_nodeType.name')}
-                link = Neos.Neos:NodeUri {
-                    baseNodeName = 'item'
-                }
-                path = ${q(item).property('_path')}
-                title = ${q(item).property('title')}
+            items = ${q(node).children('[instanceof Neos.Neos:Document]')}
+            itemName = 'node'
+            itemRenderer = NeosExampleJsonApi.Site:DefaultView.Json {
 
-                content = Neos.Fusion:Map {
-                    items = ${q(item).children('main').children()}
-                    itemName = 'item'
-                    itemRenderer = Neos.Fusion:Case {
-                        jsonView {
-                            condition = Neos.Fusion:CanRender {
-                                type = ${q(item).property('_nodeType.name') + '.Json'}
-                            }
-                            type = ${q(item).property('_nodeType.name') + '.Json'}
-                            @context.node = ${item}
-                        }
-                        defaultView {
-                            condition = true
-                            type = 'NeosExampleJsonApi.Site:DefaultView.Json'
-                            @context.node = ${item}
-                        }
-                    }
+                nodeTitle = ${q(node).property('title')}
+                nodeUri = Neos.Neos:NodeUri {
+                    node = ${node}
                 }
-            }
+                nodePath = ${q(node).property('_path')}
+
+                content = NeosExampleJsonApi.Site:ContentCollectionJson {
+                    nodePath = 'main'
+                }
+
         }
+
     }
 
     @process.stringify = ${Json.stringify(value)}

--- a/DistributionPackages/NeosExampleJsonApi.Site/Resources/Private/Fusion/JsonApi/ContentCollectionJson.fusion
+++ b/DistributionPackages/NeosExampleJsonApi.Site/Resources/Private/Fusion/JsonApi/ContentCollectionJson.fusion
@@ -1,0 +1,24 @@
+prototype(NeosExampleJsonApi.Site:ContentCollectionJson) < prototype(Neos.Fusion:Map) {
+
+    nodePath = 'to-be-set-by-user'
+
+    // Neos.Node.nearestContentCollection:
+    // Check if the given node is already a collection, find collection by nodePath otherwise,
+    // throw exception if no content collection could be found
+    @context.node = ${Neos.Node.nearestContentCollection(node, this.nodePath)}
+
+    items = ${q(node).children()}
+    itemName = 'node'
+    itemRenderer = Neos.Fusion:Case {
+        explicitJsonView {
+            condition = Neos.Fusion:CanRender {
+                type = ${q(node).property('_nodeType.name') + '.Json'}
+            }
+            type = ${q(node).property('_nodeType.name') + '.Json'}
+        }
+        defaultJsonView {
+            condition = true
+            type = 'NeosExampleJsonApi.Site:DefaultView.Json'
+        }
+    }
+}

--- a/DistributionPackages/NeosExampleJsonApi.Site/Resources/Private/Fusion/JsonApi/DefaultViewJson.fusion
+++ b/DistributionPackages/NeosExampleJsonApi.Site/Resources/Private/Fusion/JsonApi/DefaultViewJson.fusion
@@ -1,6 +1,6 @@
-prototype(NeosExampleJsonApi.Site:DefaultView.Json) < prototype(Neos.Fusion:Component) {
-    renderer = Neos.Fusion:DataStructure {
-        nodeId = ${node.identifier}
-        nodeType = ${q(node).property('_nodeType.name')}
-    }
+prototype(NeosExampleJsonApi.Site:DefaultView.Json) < prototype(Neos.Fusion:DataStructure) {
+    nodeId = ${node.identifier}
+    nodeId.@position = "start 100"
+    nodeType = ${q(node).property('_nodeType.name')}
+    nodeType.@position = "start 50"
 }

--- a/DistributionPackages/NeosExampleJsonApi.Site/Resources/Private/Fusion/JsonApi/JsonApi.fusion
+++ b/DistributionPackages/NeosExampleJsonApi.Site/Resources/Private/Fusion/JsonApi/JsonApi.fusion
@@ -3,10 +3,8 @@ json = Neos.Fusion:Http.Message {
         headers.Content-Type = 'application/json'
     }
 
-    nodeTypeCase = Neos.Fusion:Case {
-        jsonView {
-            condition = true
-            type = ${q(node).property('_nodeType.name') + '.Json'}
-        }
+    nodeTypeCase = Neos.Fusion:Renderer {
+        type = ${q(node).property('_nodeType.name') + '.Json'}
     }
+
 }


### PR DESCRIPTION
Make code DRY by using the NeosExampleJsonApi.Site:DefaultView.Json as base for Json rendering

and make the page render more readable with a Json Content Collection

use in Loops (Maps) the itemName = "node" to easily override the context.